### PR TITLE
Check if bootloader is detected from flasher

### DIFF
--- a/flasher.h
+++ b/flasher.h
@@ -40,9 +40,7 @@
 #include <QJsonObject>
 #include <QThread>
 
-namespace communication {
-class SerialPort;
-} // namespace communication
+#include "serial_port.h"
 
 QT_BEGIN_NAMESPACE
 class Worker : public QObject
@@ -83,7 +81,6 @@ public:
     ~Flasher();
 
     void init();
-    std::shared_ptr<communication::SerialPort> getSerialPort() const;
     bool startErase();
     std::tuple<bool, QString, QString> startFlash();
     bool crcCheck(const uint8_t* data, uint32_t size);
@@ -91,11 +88,13 @@ public:
     bool checkTrue();
     bool CollectBoardId();
     bool GetBoardKey();
+    bool IsBootloaderDetected() const;
     bool OpenFirmwareFile(const QString& filePath);
     void SendFlashCommand();
     void SetState(const FlasherStates& state);
-    bool sendEnableFirmwareProtection(void);
-    bool sendDisableFirmwareProtection(void);
+    bool sendEnableFirmwareProtection();
+    bool sendDisableFirmwareProtection();
+    void TryToConnect();
 
 signals:
     void updateProgress(const qint64& dataPosition, const qint64& firmwareSize);
@@ -115,7 +114,6 @@ public slots:
 
 private:
     QThread workerThread;
-    std::shared_ptr<communication::SerialPort> m_serialPort;
     QFile m_fileFirmware;
     QFile m_keysFile;
 
@@ -126,6 +124,9 @@ private:
     QJsonObject m_jsonObject;
     bool m_isTryConnectStart {false};
     QElapsedTimer m_timerTryConnect;
+
+    bool is_bootloader_ {false};
+    communication::SerialPort serial_port_;
 
     bool GetBoardKeyFromServer();
     void GetVersion();

--- a/main.cpp
+++ b/main.cpp
@@ -53,10 +53,9 @@ int main(int argc, char *argv[])
         QString actionString = argv[1];
         QString filePath = argv[2];
 
-        //This is a blocking solution only for the console. No init needed.
-        flasher->getSerialPort()->openConnBlocking();
+        flasher->TryToConnect();
 
-        if (!(flasher->getSerialPort()->isBootloaderDetected())) {
+        if (!(flasher->IsBootloaderDetected())) {
             flasher->SendFlashCommand();
             qInfo() << "Unplug USB run this app again and plug USB! ";
 

--- a/mainwindow.cpp
+++ b/mainwindow.cpp
@@ -85,7 +85,6 @@ MainWindow::MainWindow(std::shared_ptr<flasher::Flasher> flasher, QWidget *paren
 
     connect(m_flasher.get(), &flasher::Flasher::isBootloader, this, [&] (const auto& isBootloader)
     {
-        m_isBootloader = isBootloader;
         m_ui.enterBootloader->setEnabled(true);
 
         if (isBootloader) {
@@ -178,11 +177,9 @@ void MainWindow::on_selectFirmware_clicked()
 
 void MainWindow::on_loadFirmware_clicked()
 {
-    if (m_isBootloader) {
-        m_ui.loadFirmware->setEnabled(false);
-        m_ui.progressBar->show();
-        m_flasher->SetState(flasher::FlasherStates::kFlash);
-    }
+    m_ui.loadFirmware->setEnabled(false);
+    m_ui.progressBar->show();
+    m_flasher->SetState(flasher::FlasherStates::kFlash);
 }
 
 void MainWindow::on_registerButton_clicked()
@@ -193,7 +190,7 @@ void MainWindow::on_registerButton_clicked()
 
 void MainWindow::on_enterBootloader_clicked()
 {
-    if (m_isBootloader) {
+    if (m_flasher->IsBootloaderDetected()) {
         m_flasher->SetState(flasher::FlasherStates::kExitBootloader);
     }
     else {

--- a/mainwindow.h
+++ b/mainwindow.h
@@ -63,7 +63,6 @@ private slots:
 private:
     Ui::MainWindow m_ui;
     std::shared_ptr<flasher::Flasher> m_flasher;
-    bool m_isBootloader {false};
     bool m_isReadProtectionEnabled {false};
 
     void ConnectActions();

--- a/serial_port.h
+++ b/serial_port.h
@@ -32,8 +32,8 @@
  *
  ****************************************************************************/
 
-#ifndef SERIAL_PORT_H
-#define SERIAL_PORT_H
+#ifndef SERIAL_PORT_H_
+#define SERIAL_PORT_H_
 
 #include <QSerialPort>
 
@@ -43,22 +43,16 @@ class SerialPort : public QSerialPort
 {
     Q_OBJECT
 
-public:
+  public:
     SerialPort();
     ~SerialPort();
-    void openConn();
-    void openConnBlocking();
-    void closeConn();
-    bool isOpen() const;
-    bool tryOpenPort();
-    bool detectBoard();
-    bool isBootloaderDetected() const;
+    void CloseConn();
+    bool TryOpenPort(bool &is_bootloader);
 
-private:
-    bool m_isBootlaoder {false};
-    bool m_isOpen {false};
-    QString m_portName;
+  private:
+    bool DetectBoard(bool &is_bootloader);
+    bool OpenConnection(const QString &port_name);
 };
 
 } // namespace communication
-#endif // SERIAL_PORT_H
+#endif // SERIAL_PORT_H_

--- a/style.astylerc
+++ b/style.astylerc
@@ -4,7 +4,7 @@
 indent=spaces=4
 
 # Indent 'class' and 'struct' access modifiers, 'public:', 'protected:' and 'private:', one half indent.
-indent-classes
+indent-modifiers
 
 # Indent 'switch' blocks so that the 'case X:' statements are indented in the switch block. The entire case block is indented.
 indent-switches


### PR DESCRIPTION
- check if bootloader is detected from flasher
- remove member m_isBootloader from mainwindow and serialport
- remove members m_portName and m_isOpen from serialport
- m_isOpen is not needed in serialport, isOpen method is already implemented in QSerialPort