### PR TITLE
Add new states (EnteringBootloader, ExitingBootloader)

### DIFF
--- a/flasher.h
+++ b/flasher.h
@@ -67,8 +67,10 @@ enum class FlasherStates {
     kCheckBoardInfo,
     kFlash,
     kEnterBootloader,
-    kExitBootloader,
+    kEnteringBootloader,
     kReconnect,
+    kExitBootloader,
+    kExitingBootloader,
     kError
 };
 
@@ -95,7 +97,7 @@ public:
     void SetState(const FlasherStates& state);
     bool sendEnableFirmwareProtection();
     bool sendDisableFirmwareProtection();
-    void TryToConnect();
+    void TryToConnectConsole();
 
 signals:
     void updateProgress(const qint64& dataPosition, const qint64& firmwareSize);
@@ -123,19 +125,22 @@ private:
     QString m_boardId;
     QString m_boardKey;
     QJsonObject m_jsonObject;
-    bool m_isTryConnectStart {false};
-    QElapsedTimer m_timerTryConnect;
 
     bool is_bootloader_ {false};
+    bool is_bootloader_expected_ {false};
+    bool is_timer_started_ {false};
     communication::SerialPort serial_port_;
+    QElapsedTimer timer_;
 
     bool GetBoardKeyFromServer();
     void GetVersion();
     bool IsFirmwareProtected();
+    void ReconnectingToBoard();
     void SaveBoardKeyToFile();
     bool SendDisconnectCmd();
     bool SendExitBootloaderCommand();
     bool SendKey();
+    void TryToConnect();
 };
 
 } // namespace flasher

--- a/main.cpp
+++ b/main.cpp
@@ -53,7 +53,7 @@ int main(int argc, char *argv[])
         QString actionString = argv[1];
         QString filePath = argv[2];
 
-        flasher->TryToConnect();
+        flasher->TryToConnectConsole();
 
         if (!(flasher->IsBootloaderDetected())) {
             if (!flasher->SendEnterBootloaderCommand()) {


### PR DESCRIPTION
- add new states (EnteringBootloader, ExitingBootloader)
- add new member that will determine if bootloader is expected after board reset
- in case of fail after trying to enter/exit bootloader, go to error state