### PR TITLE
Introduced getting version info over JSON format

### DIFF
--- a/flasher.cpp
+++ b/flasher.cpp
@@ -67,6 +67,7 @@ constexpr int kTryToConnectTimeoutInMs {20000};
 constexpr char kVerifyFlasherCmd[] = "IMFlasher_Verify";
 constexpr char kEraseCmd[] = "erase";
 constexpr char kVersionCmd[] = "version";
+constexpr char kVersionJsonCmd[] = "version_json";
 constexpr char kBoardIdCmd[] = "board_id";
 constexpr char kFlashFwCmd[] = "flash_fw";
 constexpr char kEnterBlCmd[] = "enter_bl";
@@ -132,13 +133,19 @@ void Flasher::LoopHandler()
     case FlasherStates::kConnected:
         emit ShowStatusMsg("Connected");
         if (serial_port_.isOpen()) {
-            GetVersion();
             emit SetButtons(is_bootloader_);
 
             if (is_bootloader_) {
+                GetVersionJson(bl_version_);
+                if (bl_version_.empty()) {
+                    GetVersion();
+                }
                 SetState(FlasherStates::kCheckBoardInfo);
-            }
-            else {
+            } else {
+                GetVersionJson(fw_version_);
+                if (fw_version_.empty()) {
+                    GetVersion();
+                }
                 SetState(FlasherStates::kIdle);
             }
         }
@@ -473,6 +480,28 @@ void Flasher::GetVersion()
     serial_port_.write(kVersionCmd, sizeof(kVersionCmd));
     serial_port_.waitForReadyRead(kSerialTimeoutInMs);
     emit ShowTextInBrowser(serial_port_.readAll());
+}
+
+bool Flasher::GetVersionJson(QJsonObject& out_json_object)
+{
+    bool success = false;
+    QByteArray out_data;
+    if(ReadMessageWithCrc(kVersionJsonCmd, sizeof(kVersionJsonCmd), kSerialTimeoutInMs, out_data)) {
+        QJsonDocument out_json_document = QJsonDocument::fromJson(QString(out_data).toUtf8());
+        out_json_object = out_json_document.object();
+
+        QString git_info = "Git branch: ";
+        git_info.append(out_json_object.value("git_branch").toString());
+        git_info.append("\nGit hash: ");
+        git_info.append(out_json_object.value("git_hash").toString());
+        git_info.append("\nGit tag: ");
+        git_info.append(out_json_object.value("git_tag").toString());
+        emit ShowTextInBrowser(git_info);
+
+        success = true;
+    }
+
+    return success;
 }
 
 bool Flasher::IsBootloaderDetected() const

--- a/flasher.h
+++ b/flasher.h
@@ -113,6 +113,8 @@ public slots:
 
 private:
     QString board_id_;
+    QJsonObject bl_version_;
+    QJsonObject fw_version_;
     QFile firmware_file_;
     bool is_bootloader_ {false};
     bool is_bootloader_expected_ {false};
@@ -126,6 +128,7 @@ private:
     bool CheckTrue();
     bool CrcCheck(const uint8_t *data, const uint32_t size);
     void GetVersion();
+    bool GetVersionJson(QJsonObject& out_json_object);
     bool IsFirmwareProtected();
     void ReconnectingToBoard();
     bool SendMessage(const char *data, qint64 length, int timeout_ms);

--- a/flasher.h
+++ b/flasher.h
@@ -129,6 +129,7 @@ private:
     bool IsFirmwareProtected();
     void ReconnectingToBoard();
     bool SendMessage(const char *data, qint64 length, int timeout_ms);
+    bool ReadMessageWithCrc(const char *data, qint64 length, int timeout_ms, QByteArray& out_data);
     void TryToConnect();
 };
 


### PR DESCRIPTION
Added `Flasher::ReadMessageWithCrc` that will request, pars, and verify messages with CRC. 
Updated `CollectBoardId` method to use `ReadMessageWithCrc` method. `ReadMessageWithCrc` can be used for receiving any other message from the bootloader that includes CRC. 

Added new method `Flasher::GetVersionJson` that will introduce a more flexible way of receiving version information from bootloader or application. 

Additionally, the board_id_ format is changed from **hex** to **base64** since base64 uses fewer data and is a better candidate for textual data transport. 