### PR TITLE
Add config file that contains config for server

### DIFF
--- a/flasher.h
+++ b/flasher.h
@@ -38,11 +38,18 @@
 #include <QElapsedTimer>
 #include <QFile>
 #include <QJsonObject>
+#include <QJsonArray>
 #include <QThread>
+#include <QFile>
 
 #include "flashing_info.h"
 #include "serial_port.h"
-#include "socket_client.h"
+
+namespace socket {
+
+class SocketClient;
+
+} // namespace socket
 
 QT_BEGIN_NAMESPACE
 class Worker : public QObject
@@ -120,13 +127,14 @@ class Flasher : public QObject
     QJsonObject bl_version_;
     QJsonObject fw_version_;
     QJsonArray product_info_;
+    QFile config_file_;
     QFile firmware_file_;
     bool is_bootloader_ {false};
     bool is_bootloader_expected_ {false};
     bool is_read_protection_enabled_ {false};
     bool is_timer_started_ {false};
     communication::SerialPort serial_port_;
-    socket::SocketClient socket_client_;
+    std::shared_ptr<socket::SocketClient> socket_client_;
     FlasherStates state_ {FlasherStates::kIdle};
     QElapsedTimer timer_;
     QThread worker_thread_;
@@ -141,8 +149,8 @@ class Flasher : public QObject
     bool SendMessage(const char *data, qint64 length, int timeout_ms);
     bool ReadMessageWithCrc(const char *in_data, qint64 length, int timeout_ms, QByteArray& out_data);
     void TryToConnect();
-
-    const QByteArray kFakeBoardId = "NOT_SECURED_MAGIC_STRING_1234567";
+    bool OpenConfigFile(QJsonDocument& json_document);
+    void CreateDefaultConfigFile();
 };
 
 } // namespace flasher

--- a/socket_client.cpp
+++ b/socket_client.cpp
@@ -40,13 +40,18 @@
 
 namespace socket {
 
-SocketClient::SocketClient() = default;
+SocketClient::SocketClient(const QString& address, const uint32_t& port, const QString& preshared_key) :
+    server_port_(port),
+    server_address_(address),
+    preshared_key_(preshared_key.toUtf8())
+{}
+
 SocketClient::~SocketClient() = default;
 
 bool SocketClient::Connect()
 {
     bool success = false;
-    connectToHost(QHostAddress::LocalHost, kPort);
+    connectToHost(server_address_, server_port_);
     if (Authentication()) {
         success = true;
     } else {
@@ -69,7 +74,7 @@ bool SocketClient::Authentication()
 {
     bool success = false;
     QMessageAuthenticationCode code(QCryptographicHash::Sha256);
-    code.setKey(kShaKey);
+    code.setKey(preshared_key_);
 
     QByteArray token;
     success = ReadAll(token);
@@ -112,7 +117,7 @@ bool SocketClient::CheckAck()
     QByteArray ack;
     success = ReadAll(ack);
 
-    if (success && (kACK == ack)) {
+    if (success && (kAck == ack)) {
         success = true;
     }
 

--- a/socket_client.h
+++ b/socket_client.h
@@ -44,15 +44,25 @@ namespace socket {
 
 namespace  {
 
-    const QString kHeaderClientBoardInfo{"header_client_board_info"};
-    const QString kHeaderClientProductInfo{"header_client_product_info"};
-    const QString kHeaderServerProductInfo{"header_server_product_info"};
+const QString kHeaderClientBoardInfo{"header_client_board_info"};
+const QString kHeaderClientProductInfo{"header_client_product_info"};
+const QString kHeaderServerProductInfo{"header_server_product_info"};
 }
 
 class SocketClient : public QTcpSocket
 {
   public:
-    SocketClient();
+
+    /**
+     * Socket client constructor
+     *
+     * @param[in] address       Address of the server
+     * @param[in] port          Port of the server
+     * @param[in] preshared_key PreShared Key
+     */
+
+    SocketClient(const QString& address, const uint32_t& port, const QString& preshared_key);
+
     virtual ~SocketClient();
 
     /**
@@ -78,16 +88,15 @@ class SocketClient : public QTcpSocket
     virtual bool Connect();
     virtual bool Disconnect();
     virtual bool Authentication();
-    virtual bool ReadAll(QByteArray &data_out);
-    virtual bool SendData(const QByteArray &in_data);
+    virtual bool ReadAll(QByteArray& data_out);
+    virtual bool SendData(const QByteArray& in_data);
     virtual bool CheckAck();
 
-    const quint16 kPort {5322};
-    const QByteArray kShaKey{"NDQ4N2Y1YjFhZTg3ZGI3MTA1MjlhYmM3"};
+    quint16 server_port_;
+    QString server_address_;
+    QByteArray preshared_key_;
 
-    const QByteArray kACK{"ACK"};
-    const QByteArray kNACK{"NACK"};
-
+    const QByteArray kAck{"ACK"};
 };
 
 } // namespace socket

--- a/tests/tst_socket.cpp
+++ b/tests/tst_socket.cpp
@@ -3,9 +3,16 @@
 #include <vector>
 #include <QMessageAuthenticationCode>
 
+constexpr char kDefaultAddress[]{"127.0.0.1"};
+constexpr int kDefaultPort = 5322;
+constexpr char kDefaultKey[]{"NDQ4N2Y1YjFhZTg3ZGI3MTA1MjlhYmM3"};
+
 class MockSocket_1 : public socket::SocketClient
 {
 public:
+    MockSocket_1(const QString& address, const uint32_t& port, const QString& preshared_key) : SocketClient(address, port, preshared_key)
+    {}
+
     std::vector<QByteArray> read_data_;
     std::vector<QByteArray> send_data_;
 private:
@@ -29,6 +36,10 @@ bool MockSocket_1::SendData(const QByteArray &in_data)
 
 class MockSocket_2 : public socket::SocketClient
 {
+public:
+    MockSocket_2(const QString& address, const uint32_t& port, const QString& preshared_key) : SocketClient(address, port, preshared_key)
+    {}
+
 private:
     bool ReadAll(QByteArray &data_out) override;
 };
@@ -41,6 +52,10 @@ bool MockSocket_2::ReadAll(QByteArray &data_out)
 
 class MockSocket_3 : public socket::SocketClient
 {
+public:
+    MockSocket_3(const QString& address, const uint32_t& port, const QString& preshared_key) : SocketClient(address, port, preshared_key)
+    {}
+
 private:
     bool ReadAll(QByteArray &data_out) override;
     bool SendData(const QByteArray &in_data) override;
@@ -54,7 +69,7 @@ bool MockSocket_3::ReadAll(QByteArray &data_out)
 
 bool MockSocket_3::SendData(const QByteArray &in_data)
 {
-    QByteArray test = in_data;
+    if (in_data.isEmpty()) {};
     return false;
 }
 
@@ -63,7 +78,7 @@ TestSocket::~TestSocket() = default;
 
 void TestSocket::TestSendBoardInfo()
 {
-    MockSocket_1 socket;
+    MockSocket_1 socket(kDefaultAddress, kDefaultPort, kDefaultKey);
 
     QString bl_git_branch = "master";
     QString bl_git_hash = "be387ad0b2ba6dc0877e8e255e872ee310a9127c";
@@ -125,7 +140,7 @@ void TestSocket::TestSendBoardInfo()
 
 void TestSocket::TestReceiveProductType()
 {
-    MockSocket_1 socket;
+    MockSocket_1 socket(kDefaultAddress, kDefaultPort, kDefaultKey);
 
     QString board_id = "test_board_id";
     QString manufacturer_id = "test_manufacturer_id";
@@ -194,7 +209,7 @@ void TestSocket::TestReceiveProductType()
 
 void TestSocket::TestReadFail()
 {
-    MockSocket_2 socket;
+    MockSocket_2 socket(kDefaultAddress, kDefaultPort, kDefaultKey);
 
     QString bl_git_branch = "master";
     QString bl_git_hash = "be387ad0b2ba6dc0877e8e255e872ee310a9127c";
@@ -229,7 +244,7 @@ void TestSocket::TestReadFail()
 
 void TestSocket::TestSendFail()
 {
-    MockSocket_3 socket;
+    MockSocket_3 socket(kDefaultAddress, kDefaultPort, kDefaultKey);
 
     QString board_id = "test_board_id";
     QString manufacturer_id = "test_manufacturer_id";


### PR DESCRIPTION
Add function to create `config.json` file with a default value. Idea is that IMFlasher has a config file that users can configure out of the box. For now, is added configuration data for connecting to the **server**. 

Default config file: 
```
{
    "server": {
        "address": "141.144.224.68",
        "port": 5322,
        "preshared_key": "NDQ4N2Y1YjFhZTg3ZGI3MTA1MjlhYmM3"
    }
}
```
The application will check if the config file exists. If exist it will load data from it. If it doesn't then it will create one. 