### PR TITLE
Add support for download firmware from URL

### DIFF
--- a/file_downloader.cpp
+++ b/file_downloader.cpp
@@ -1,0 +1,73 @@
+/****************************************************************************
+ *
+ *   Copyright (c) 2022 IMProject Development Team. All rights reserved.
+ *   Authors: Igor Misic <igy1000mb@gmail.com>
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in
+ *    the documentation and/or other materials provided with the
+ *    distribution.
+ * 3. Neither the name IMProject nor the names of its contributors may be
+ *    used to endorse or promote products derived from this software
+ *    without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS
+ * FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE
+ * COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT,
+ * INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING,
+ * BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS
+ * OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED
+ * AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
+ * LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN
+ * ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ * POSSIBILITY OF SUCH DAMAGE.
+ *
+ ****************************************************************************/
+
+#include "file_downloader.h"
+
+namespace file_downloader {
+
+FileDownloader::FileDownloader() = default;
+FileDownloader::~FileDownloader() = default;
+
+void FileDownloader::StartDownload(const QUrl& url)
+{
+    QNetworkRequest request(url);
+    request.setSslConfiguration(QSslConfiguration::defaultConfiguration());
+    reply_ = net_access_manager_.get(request);
+    connect(reply_, &QNetworkReply::downloadProgress,this, &FileDownloader::SetDownloadProgress);
+    connect(reply_, &QNetworkReply::finished, this, &FileDownloader::FileDownloaded);
+}
+
+void FileDownloader::SetDownloadProgress(qint64 bytes_received, qint64 bytes_total)
+{
+    emit DownloadProgress(bytes_received, bytes_total);
+}
+
+void FileDownloader::FileDownloaded() {
+    emit Downloaded();
+}
+
+bool FileDownloader::GetDownloadedData(QByteArray& downloaded_data) {
+
+    bool success = false;
+
+    if(reply_ != nullptr) {
+        downloaded_data = reply_->readAll();
+        reply_->deleteLater();
+        success = true;
+    }
+
+    return success;
+}
+
+} // namespace file_downloader

--- a/file_downloader.h
+++ b/file_downloader.h
@@ -1,0 +1,69 @@
+/****************************************************************************
+ *
+ *   Copyright (c) 2022 IMProject Development Team. All rights reserved.
+ *   Authors: Igor Misic <igy1000mb@gmail.com>
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in
+ *    the documentation and/or other materials provided with the
+ *    distribution.
+ * 3. Neither the name IMProject nor the names of its contributors may be
+ *    used to endorse or promote products derived from this software
+ *    without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS
+ * FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE
+ * COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT,
+ * INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING,
+ * BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS
+ * OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED
+ * AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
+ * LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN
+ * ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ * POSSIBILITY OF SUCH DAMAGE.
+ *
+ ****************************************************************************/
+
+#ifndef FILE_DOWNLOADER_H_
+#define FILE_DOWNLOADER_H_
+
+#include <QObject>
+#include <QByteArray>
+#include <QNetworkAccessManager>
+#include <QNetworkRequest>
+#include <QNetworkReply>
+
+namespace file_downloader {
+
+class FileDownloader : public QObject
+{
+    Q_OBJECT
+  public:
+    FileDownloader();
+    virtual ~FileDownloader();
+    virtual void StartDownload(const QUrl& url);
+    virtual bool GetDownloadedData(QByteArray& downloaded_data);
+
+  signals:
+    void Downloaded();
+    void DownloadProgress(const qint64& bytes_received, const qint64& bytes_total);
+
+  private slots:
+    void SetDownloadProgress(qint64 bytes_received, qint64 bytes_total);
+    void FileDownloaded();
+  private:
+    QNetworkAccessManager net_access_manager_;
+    QNetworkReply *reply_;
+};
+
+} // namespace file_downloader
+
+#endif // FILE_DOWNLOADER_H_

--- a/imflasher.pro
+++ b/imflasher.pro
@@ -14,6 +14,7 @@ DEFINES += GIT_HASH=\\\"$$GIT_HASH\\\"
 DEFINES += GIT_BRANCH=\\\"$$GIT_BRANCH\\\"
 SOURCES += \
     crc32.cpp \
+    file_downloader.cpp \
     flasher.cpp \
     main.cpp \
     mainwindow.cpp \
@@ -22,6 +23,7 @@ SOURCES += \
 
 HEADERS += \
     crc32.h \
+    file_downloader.h \
     flasher.h \
     flashing_info.h \
     mainwindow.h \

--- a/mainwindow.h
+++ b/mainwindow.h
@@ -36,6 +36,7 @@
 #define MAINWINDOW_H_
 
 #include <QMainWindow>
+#include <QJsonArray>
 
 #include "ui_mainwindow.h"
 
@@ -54,7 +55,7 @@ class MainWindow : public QMainWindow
     ~MainWindow();
 
   private slots:
-    void on_selectFirmware_clicked();
+    void on_browseFirmware_clicked();
     void on_loadFirmware_clicked();
     void on_enterBootloader_clicked();
     void on_protectButton_clicked();
@@ -73,6 +74,7 @@ class MainWindow : public QMainWindow
     void DisableAllButtons();
     void InitActions();
     void ShowStatusMessage(const QString& message);
+    void SetFirmwareList(const QJsonArray& product_info);
 };
 
 } // namespace gui

--- a/mainwindow.ui
+++ b/mainwindow.ui
@@ -67,7 +67,7 @@
       </widget>
      </item>
      <item>
-      <widget class="QPushButton" name="selectFirmware">
+      <widget class="QPushButton" name="browseFirmware">
        <property name="sizePolicy">
         <sizepolicy hsizetype="Minimum" vsizetype="Fixed">
          <horstretch>0</horstretch>
@@ -81,7 +81,14 @@
         </size>
        </property>
        <property name="text">
-        <string>Firmware</string>
+        <string>Browse</string>
+       </property>
+      </widget>
+     </item>
+     <item>
+      <widget class="QComboBox" name="availableFirmware">
+       <property name="layoutDirection">
+        <enum>Qt::LeftToRight</enum>
        </property>
       </widget>
      </item>
@@ -127,7 +134,7 @@
      <x>0</x>
      <y>0</y>
      <width>676</width>
-     <height>27</height>
+     <height>19</height>
     </rect>
    </property>
    <widget class="QMenu" name="menuCalls">


### PR DESCRIPTION
Added support for showing the available list of firmware from the server
![image](https://user-images.githubusercontent.com/10188706/158066329-164dd02f-1ce6-43ce-b723-b2352fd3f2d1.png)
Users can select, download, and flash the firmware directly from the IMFlasher. 

- The firmware button is renamed to **Browse** to be more understandable. 

- The progress bar function is now protected from firmware size 0. It is also reused to show firmware downloading status from the URL. 

Know issues: Win10 1809 has a problem while using the OpenSSL library and it is showing errors and slowing down the function of the whole application. Win11 needs OpenSSL 1.1.1 library in executable directory. 