### PR TITLE
flasher: if there is no app, try to connect to BL again

### DIFF
--- a/flasher.cpp
+++ b/flasher.cpp
@@ -769,7 +769,7 @@ void Flasher::ReconnectingToBoard()
 
         if (timer_.hasExpired(kTryToConnectTimeoutInMs)) {
             ShowInfoMsg("Error!", "Entering/Exiting bootloader cannot be performed!");
-            SetState(FlasherStates::kError);
+            SetState(FlasherStates::kTryToConnect);
             is_timer_started_ = false;
         }
 


### PR DESCRIPTION
- in case there is no application, exiting bootloader will fail and we will stuck in error state
- with this solution, if there is no application, we will connect to the bootloader automatically, and application will be ready for usage again