### PR TITLE
flasher: use isOpen() to check if the binary is open over the browser

### DIFF
--- a/flasher.cpp
+++ b/flasher.cpp
@@ -848,7 +848,7 @@ void Flasher::SendFlashCommand() {
 }
 
 bool Flasher::SetLocalFileContent() {
-    if (firmware_file_.size() != 0) {
+    if (firmware_file_.isOpen()) {
         file_content_ = firmware_file_.readAll();
         firmware_file_.close();
         return true;


### PR DESCRIPTION
If the file is first browsed and after that downloaded from the server, the firmware size will be wrong. 
This detects if the file was browsed by checking if it is open.  
![flasher_bug](https://user-images.githubusercontent.com/10188706/167913912-c599e7e7-faf2-4100-aeea-0d1c68318880.png)
