### PR TITLE
Update progress bar only on change and use DirectConnection signal-slot type

### DIFF
--- a/flasher.h
+++ b/flasher.h
@@ -159,13 +159,19 @@ class Flasher : public QObject {
      */
     void TryToConnectConsole();
 
+    /*!
+    * \brief Update progress bar
+    * \param sent_size - Size that is sent
+    * \param firmware_size - Firmware size
+    */
+   void UpdateProgressBar(const quint64& sent_size, const quint64& firmware_size);
+
   signals:
     /*!
-     * \brief UpdateProgressBar signal
-     * \param sent_size - Size that is sent
-     * \param firmware_size - Firmware size
+     * \brief Update progress bar signal
+     * \param progress_percentage - value for the update in percentage
      */
-    void UpdateProgressBar(const qint64& sent_size, const qint64& firmware_size);
+    void UpdateProgressBarSignal(const qint8& progress_percentage);
 
     /*!
      * \brief Clear progress signal
@@ -276,6 +282,7 @@ class Flasher : public QObject {
     QFile config_file_;                                                     //!< Configuration file
     QFile firmware_file_;                                                   //!< Firmware file
     qint64 signature_size_{0};                                              //!< Firmware signature size
+    quint8 last_progress_percentage_{0};                                    //!< Last progress percentage
     bool is_bootloader_ {false};                                            //!< Is bootloader detected flag
     bool is_bootloader_expected_ {false};                                   //!< Is bootloader expected after board reset
     bool is_read_protection_enabled_ {false};                               //!< Is read protection enabled flag

--- a/mainwindow.cpp
+++ b/mainwindow.cpp
@@ -53,7 +53,7 @@ MainWindow::MainWindow(std::shared_ptr<flasher::Flasher> flasher) :
 
     connect(flasher_.get(), &flasher::Flasher::UpdateProgressBarSignal, this, [&] (const quint8& progress_percentage) { // *NOPAD*
         ui_.progressBar->setValue(progress_percentage);
-    });
+    }, Qt::DirectConnection);
 
     connect(flasher_.get(), &flasher::Flasher::ClearProgress, this, &MainWindow::ClearProgress);
 

--- a/mainwindow.cpp
+++ b/mainwindow.cpp
@@ -51,14 +51,8 @@ MainWindow::MainWindow(std::shared_ptr<flasher::Flasher> flasher) :
     DisableAllButtons();
     ClearProgress();
 
-    connect(flasher_.get(), &flasher::Flasher::UpdateProgressBar, this, [&] (const qint64& sent_size, const qint64& firmware_size) { // *NOPAD*
-        int progress_percentage = 0;
-        if (firmware_size != 0) {
-            progress_percentage = (100 * sent_size) / firmware_size;
-        }
-
+    connect(flasher_.get(), &flasher::Flasher::UpdateProgressBarSignal, this, [&] (const quint8& progress_percentage) { // *NOPAD*
         ui_.progressBar->setValue(progress_percentage);
-        qInfo() << sent_size << "/" << firmware_size << "B, " << progress_percentage << "%";
     });
 
     connect(flasher_.get(), &flasher::Flasher::ClearProgress, this, &MainWindow::ClearProgress);


### PR DESCRIPTION
Fix GUI performance for MS Windows with:
- update the progress bar only on change
- use DirectConnection signal-slot type for progress bar update